### PR TITLE
Variants of wait_while_low/wait_while_high with timeout

### DIFF
--- a/avr-tester/src/pins/digital_pin.rs
+++ b/avr-tester/src/pins/digital_pin.rs
@@ -97,6 +97,32 @@ impl<'a> DigitalPin<'a> {
         tt
     }
 
+    /// Waits until pin becomes high or timeout is reached; if the pin is
+    /// already high, exits immediately.
+    ///
+    /// Returns a result containing the amount of time that has passed
+    /// for the device.
+    ///
+    /// If the timeout was reached before the pin state changed, the
+    /// duration will be contained in the `Err` variant, otherwise
+    /// the `Ok` variant contains the duration it took for the pin to
+    /// get high.
+    pub fn wait_while_low_timeout(
+        &mut self,
+        timeout: AvrDuration,
+    ) -> Result<AvrDuration, AvrDuration> {
+        let mut tt = AvrDuration::zero(self.avr);
+
+        while self.is_low() {
+            if tt >= timeout {
+                return Err(tt);
+            }
+            tt += self.avr.run();
+        }
+
+        Ok(tt)
+    }
+
     /// Waits until pin becomes low; if the pin is already low, exits
     /// immediately.
     ///
@@ -109,6 +135,32 @@ impl<'a> DigitalPin<'a> {
         }
 
         tt
+    }
+
+    /// Waits until pin becomes low or timeout is reached; if the pin is
+    /// already low, exits immediately.
+    ///
+    /// Returns a result containing the amount of time that has passed
+    /// for the device.
+    ///
+    /// If the timeout was reached before the pin state changed, the
+    /// duration will be contained in the `Err` variant, otherwise
+    /// the `Ok` variant contains the duration it took for the pin to
+    /// get low.
+    pub fn wait_while_high_timeout(
+        &mut self,
+        timeout: AvrDuration,
+    ) -> Result<AvrDuration, AvrDuration> {
+        let mut tt = AvrDuration::zero(self.avr);
+
+        while self.is_high() {
+            if tt >= timeout {
+                return Err(tt);
+            }
+            tt += self.avr.run();
+        }
+
+        Ok(tt)
     }
 
     /// Return pin's name, e.g. `PC6`.

--- a/avr-tester/tests/tests/pins-digital.rs
+++ b/avr-tester/tests/tests/pins-digital.rs
@@ -83,7 +83,7 @@ fn precise() {
 /// hand-written loops.
 #[test]
 fn precise_idiomatic() {
-    let mut avr = avr_with("pins-digital", |avr| avr.with_timeout_of_s(1));
+    let mut avr = avr_with("pins-digital", |avr| avr.with_timeout_of_s(2));
 
     // Give the firmware a moment to initialize
     avr.run_for_us(100);
@@ -101,6 +101,37 @@ fn precise_idiomatic() {
     assert_eq!(100, avr.pins().pd0().pulse_in().as_millis());
     assert_eq!(150, avr.pins().pd0().pulse_in().as_millis());
     assert_eq!(150, avr.pins().pd0().pulse_in().as_millis());
+
+    // Wait for a pin change or timeout:
+    let timeout = AvrDuration::millis(&avr, 50);
+    assert_eq!(
+        Err(50),
+        avr.pins()
+            .pd0()
+            .wait_while_high_timeout(timeout)
+            .map_err(|d| d.as_millis())
+    );
+    assert_eq!(
+        Ok(50),
+        avr.pins()
+            .pd0()
+            .wait_while_high_timeout(timeout)
+            .map(|d| d.as_millis())
+    );
+    assert_eq!(
+        Err(50),
+        avr.pins()
+            .pd0()
+            .wait_while_low_timeout(timeout)
+            .map_err(|d| d.as_millis())
+    );
+    assert_eq!(
+        Ok(50),
+        avr.pins()
+            .pd0()
+            .wait_while_low_timeout(timeout)
+            .map(|d| d.as_millis())
+    );
 }
 
 /// Similar to [`precise()`], but in this case we "accidentally" assert the


### PR DESCRIPTION
Adds `wait_while_low_timeout` and `wait_while_high_timeout` methods to `DigitalPin`.

These versions behave like their counterparts without `_timeout`, except that they don't loop forever if the pin never changes, but return early if the given timeout was reached.

Example:
```
let timeout = AvrDuration::millis(&avr, 100);
match avr.wait_while_low_timeout(timeout) {
    Ok(t) => println!("Rising edge after {t:?}"),
    Err(t) => println!("Timed out while waiting for rising edge: {t:?}"),
}
```

This makes it possible to write tests which loop while there is activity on a given pin, and then use the pin going quiet for a while as a trigger for carrying on with the next test step.

It's is different from the "global" timeout set via `AvrTesterBuilder`'s `with_timeout`, which will panic when the timeout is reached.
