### PR TITLE
send and receive messages byte by byte in spi test

### DIFF
--- a/avr-tester/tests/examples/spi.rs
+++ b/avr-tester/tests/examples/spi.rs
@@ -18,10 +18,11 @@ fn test() {
     assert_eq!("Ready!", avr.spi0().read::<String>());
 
     let mut assert = |given: &str, expected: &str| {
-        avr.spi0().write(given);
-        avr.run_for_ms(50);
-
-        assert_eq!(expected, avr.spi0().read::<String>());
+        for (out, exp) in given.bytes().zip(expected.bytes()) {
+            avr.spi0().write(out);
+            avr.run_for_ms(1);
+            assert_eq!(exp, avr.spi0().read());
+        }
     };
 
     assert("Hello, World!", "Uryyb, Jbeyq!");


### PR DESCRIPTION
The firmware used in this test reads just one byte before sending the result back, so this test should work the same way, otherwise we're relying on buffering within simavr, making the test less realistic