### PR TITLE
update spi slave test to be more realistic

### DIFF
--- a/avr-simulator/src/lib.rs
+++ b/avr-simulator/src/lib.rs
@@ -109,10 +109,6 @@ impl AvrSimulator {
     }
 
     pub fn step(&mut self) -> StepOutcome {
-        for spi in self.spis.values_mut() {
-            spi.flush();
-        }
-
         for uart in self.uarts.values_mut() {
             uart.flush();
         }
@@ -121,10 +117,6 @@ impl AvrSimulator {
         let state = self.avr.run();
         let tt = (self.avr.cycle() - cycle).max(1);
         let tt = AvrDuration::new(self.avr.frequency(), tt);
-
-        for spi in self.spis.values_mut() {
-            spi.tick(tt.as_cycles());
-        }
 
         StepOutcome { state, tt }
     }

--- a/avr-tester-fixtures/src/spi.rs
+++ b/avr-tester-fixtures/src/spi.rs
@@ -6,8 +6,7 @@
 #[cfg(feature = "custom-compiler-builtins")]
 extern crate custom_compiler_builtins;
 
-use atmega_hal::{pins, Peripherals};
-use atmega_hal::{spi, Spi};
+use atmega_hal::{Peripherals, Spi, pins, spi};
 use avr_hal_generic::nb;
 use avr_hal_generic::void::ResultVoidExt;
 use embedded_hal::spi::FullDuplex;
@@ -33,12 +32,9 @@ fn main() -> ! {
 
     loop {
         let c = nb::block!(spi.read()).void_unwrap();
+        let c = rot13(c);
 
-        if c != 0 {
-            let c = rot13(c);
-
-            nb::block!(spi.send(c)).void_unwrap();
-        }
+        nb::block!(spi.send(c)).void_unwrap();
     }
 }
 

--- a/avr-tester/tests/examples/spi.rs
+++ b/avr-tester/tests/examples/spi.rs
@@ -3,7 +3,7 @@
 //! We're given an AVR that implements a ROT13 encoder and we basically assert
 //! that the encoder works.
 //!
-//! See: [../../../avr-tester-fixtures/spi/src/main.rs].
+//! See: [../../../avr-tester-fixtures/src/spi.rs].
 
 use avr_tester::AvrTester;
 
@@ -13,23 +13,25 @@ fn test() {
         .with_clock_of_16_mhz()
         .load("../avr-tester-fixtures/target/avr-none/release/spi.elf");
 
-    avr.run_for_ms(1);
-
-    assert_eq!("Ready!", avr.spi0().read::<String>());
-
-    let mut assert = |given: &str, expected: &str| {
-        avr.spi0().write(given);
-        avr.run_for_ms(50);
-
-        assert_eq!(expected, avr.spi0().read::<String>());
-    };
-
-    assert("Hello, World!", "Uryyb, Jbeyq!");
-
-    assert(
+    avr.spi0().write([0u8; 5]);
+    avr.spi0().write("Hello, World!");
+    avr.spi0().write(
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent \
-          non maximus purus. Fusce a neque condimentum, finibus dui et, tempor",
-        "Yberz vcfhz qbybe fvg nzrg, pbafrpgrghe nqvcvfpvat ryvg. Cenrfrag \
-          aba znkvzhf chehf. Shfpr n ardhr pbaqvzraghz, svavohf qhv rg, grzcbe",
+    non maximus purus. Fusce a neque condimentum, finibus dui et, tempor",
+    );
+
+    avr.run_for_ms(10);
+
+    assert_eq!(Ok("Ready!"), str::from_utf8(&avr.spi0().read::<[u8; 6]>()));
+    assert_eq!(
+        Ok("Uryyb, Jbeyq!"),
+        str::from_utf8(&avr.spi0().read::<[u8; 13]>())
+    );
+    assert_eq!(
+        Ok(
+            "Yberz vcfhz qbybe fvg nzrg, pbafrpgrghe nqvcvfpvat ryvg. Cenrfrag \
+        aba znkvzhf chehf. Shfpr n ardhr pbaqvzraghz, svavohf qhv rg, grzcbe"
+        ),
+        str::from_utf8(&avr.spi0().read::<[u8; 134]>())
     );
 }


### PR DESCRIPTION
As discussed on https://github.com/Patryk27/simavr-ffi/pull/8
Supersedes https://github.com/Patryk27/avr-tester/pull/8, with the agreed implementation:

* Update the SPI component of avr-simulator, removing the (not-working) slave mode support, and improving master mode support.
* Update the SPI test and fixture to represent an SPI master scenario more realistically. This test will pass before and after `simavr` is updated to the latest version.